### PR TITLE
11-3 サービス処理を確認しよう

### DIFF
--- a/src/main/java/com/example/quiz/QuizAppApplication.java
+++ b/src/main/java/com/example/quiz/QuizAppApplication.java
@@ -1,6 +1,7 @@
 package com.example.quiz;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,14 +9,14 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 import com.example.quiz.entity.Quiz;
-import com.example.quiz.repository.QuizRepository;
+import com.example.quiz.service.QuizService;
 
 
 @SpringBootApplication
 public class QuizAppApplication {
 
     @Autowired
-    private QuizRepository repo;
+    private QuizService service;
 
     public static void main(String[] args) {
         SpringApplication.run(QuizAppApplication.class, args)
@@ -23,36 +24,38 @@ public class QuizAppApplication {
     }
 
     private void execute() {
-//        // 登録
-//        setup();
-//        // 全件取得
-//        showList();
-//        // 1件取得
-//        showOne(1);
-//        // 更新処理
-//        updateQuiz(1);
-//        showOne(1);
-//        // 削除処理
-//        deleteQuiz(2);
+        // 登録
+        setup();
+        // 全件取得
+        showList();
+        // 1件取得
+        showOne(1);
+        // 更新処理
+        updateQuiz(1);
+        showOne(1);
+        // 削除処理
+        deleteQuiz(2);
+        // クイズを実行
+        doQuiz();
     }
 
     private void setup() {
         // テーブルクリア
-        repo.deleteAll();
+        service.deleteAll();
         // シリアル採番値初期化
-        repo.resetIdentity();
-        initRecords().stream().forEach(entity -> repo.save(entity));
+        service.resetIdentity();
+        initRecords().stream().forEach(entity -> service.insertQuiz(entity));
     }
 
     private void showList() {
         System.out.println("--- 全件取得開始 ---");
-        repo.findAll().forEach(quiz -> System.out.println(quiz));
+        service.selectAll().forEach(quiz -> System.out.println(quiz));
         System.out.println("--- 全件取得完了 ---");
     }
 
     private void showOne(Integer id) {
         System.out.println("--- 1件取得開始 ---");
-        repo.findById(id).ifPresentOrElse(entity -> {
+        service.selectOneById(id).ifPresentOrElse(entity -> {
             System.out.println(entity);
         }, () -> {
             System.out.println("該当する問題が存在しません・・・");
@@ -62,8 +65,8 @@ public class QuizAppApplication {
 
     private void updateQuiz(Integer id) {
         System.out.println("--- 更新処理開始 ---");
-        Quiz quiz1 = repo.findById(id).orElseThrow();
-        repo.save(Quiz.builder()
+        Quiz quiz1 = service.selectOneById(id).orElseThrow();
+        service.insertQuiz(Quiz.builder()
                 .id(quiz1.id())
                 .question("「スプリング」はフレームワークですか？")
                 .answer(quiz1.answer())
@@ -73,10 +76,34 @@ public class QuizAppApplication {
 
     private void deleteQuiz(Integer id) {
         System.out.println("--- 削除処理開始 ---");
-        repo.deleteById(id);
+        service.deleteQuizById(id);
         System.out.println("--- 削除処理終了 ---");
     }
 
+    private void doQuiz() {
+        System.out.println("--- クイズ1件取得開始 ---");
+        Optional<Quiz> optQuiz = service.selectOneRandom();
+        optQuiz.ifPresentOrElse(quiz -> {
+            System.out.println(quiz);
+            // 解答確認
+            Boolean myAnswer = false;
+            checkAnswer(optQuiz.get(), myAnswer);
+        }, () -> {
+            System.out.println("該当する問題が存在しません・・・");
+        });
+        System.out.println("--- クイズ1件取得終了 ---");
+    }
+
+    private void checkAnswer(Quiz quiz, Boolean myAns) {
+        System.out.println("設問：" + quiz.question());
+        System.out.println("あなたの回答：" + (myAns ? "○" : "×"));
+        if (service.checkAnswer(quiz.id(), myAns)) {
+            System.out.println("正解です！");
+        } else {
+            System.out.println("不正解です・・・");
+        }
+    }
+    
     /**
      * 登録レコード生成
      * @return
@@ -85,12 +112,29 @@ public class QuizAppApplication {
         return Stream.of(
                 // レコード１
                 Quiz.builder()
-                .question("「Spring」はフレームワークですか？")
+                .question("「Java」はオブジェクト指向言語である。")
                 .answer(true)
                 .author("sys").build(),
                 // レコード２
                 Quiz.builder()
-                .question("「Spring MVC」はバッチ機能を提供しますか？")
+                .question("「Spring Data」はデータアクセスに対する機能を提供する。")
+                .answer(true)
+                .author("sys").build(),
+                // レコード３
+                Quiz.builder()
+                .question("プログラムが沢山配置されているサーバーのことを「ライブラリ」という。")
+                .answer(false)
+                .author("sys").build(),
+                // レコード４
+                Quiz.builder()
+                .question("「@Component」はインスタンス生成アノテーションである。")
+                .answer(true)
+                .author("sys").build(),
+                // レコード５
+                Quiz.builder()
+                .question("「Spring MVC」が実装している「デザインパターン」で"
+                        + "全てのリクエストを１つのコントローラーで受け取るパターンは"
+                        + "「シングルコントローラ・パターン」である。")
                 .answer(false)
                 .author("sys").build()).toList();
     }

--- a/src/main/java/com/example/quiz/QuizAppApplication.java
+++ b/src/main/java/com/example/quiz/QuizAppApplication.java
@@ -26,17 +26,17 @@ public class QuizAppApplication {
     private void execute() {
         // 登録
         setup();
-        // 全件取得
-        showList();
-        // 1件取得
-        showOne(1);
-        // 更新処理
-        updateQuiz(1);
-        showOne(1);
-        // 削除処理
-        deleteQuiz(2);
-        // クイズを実行
-        doQuiz();
+//        // 全件取得
+//        showList();
+//        // 1件取得
+//        showOne(1);
+//        // 更新処理
+//        updateQuiz(1);
+//        showOne(1);
+//        // 削除処理
+//        deleteQuiz(2);
+//        // クイズを実行
+//        doQuiz();
     }
 
     private void setup() {

--- a/src/main/java/com/example/quiz/service/QuizService.java
+++ b/src/main/java/com/example/quiz/service/QuizService.java
@@ -19,4 +19,8 @@ public interface QuizService {
     void updateQuiz(Quiz quiz);
     /** クイズを削除します */
     void deleteQuizById(Integer id);
+    /** クイズを全削除します */
+    void deleteAll();
+    /** シリアルIDの採番をリセットします */
+    void resetIdentity();
 }

--- a/src/main/java/com/example/quiz/service/impl/QuizServiceImpl.java
+++ b/src/main/java/com/example/quiz/service/impl/QuizServiceImpl.java
@@ -60,4 +60,14 @@ public class QuizServiceImpl implements QuizService {
     public void deleteQuizById(Integer id) {
         repo.deleteById(id);
     }
+
+    @Override
+    public void deleteAll() {
+        repo.deleteAll();
+    }
+
+    @Override
+    public void resetIdentity() {
+        repo.resetIdentity();
+    }
 }


### PR DESCRIPTION
## サービス処理の確認を追加

* ほぼ、書籍通りの実装
* 登録処理はQuizAppApplicationに残し、初期データが登録されるように。
* 答えの確認処理は、クイズレコードがない場合にid取得で失敗するので、メソッドに切り分けて、レコード存在時のみ実行